### PR TITLE
Don't check Major Holidays box when other boxes are checked

### DIFF
--- a/hebcal.com/hebcal/index.cgi
+++ b/hebcal.com/hebcal/index.cgi
@@ -1255,9 +1255,6 @@ d.getElementById("maj").onclick=function(){
   });
  }
 };
-["nx","mf","ss","min","mod"].forEach(function(x){
- d.getElementById(x).onclick=function(){if(this.checked==true){d.f1.maj.checked=true;}}
-});
 d.getElementById("d1").onclick=function(){
   if (this.checked) {
     d.getElementById("d2").checked = false;


### PR DESCRIPTION
I'm not sure what the decision was behind this check, but this is preventing me from creating separate calendars for things like just Rosh Chodesh and just fast days. When I add all the events to a single calendar, my main calendar gets too crowded and it would be a much nicer experience if I can create separate calendars so I can hide individual items. If there is no reason for Major Holdidays to always be checked, it would be nice if this enforcement was removed.

Thank you for creating this great cal generator!